### PR TITLE
Allow custom git locations

### DIFF
--- a/API.md
+++ b/API.md
@@ -60,6 +60,7 @@ Name | Type | Description
 **clientSecret** | <code>string</code> | The client secret to be accompanied with clientId for Github APIs to authenticate the client.
 **cognitoHostedUiDomain** | <code>string</code> | The Cognito hosted UI domain.
 **userPool** | <code>[UserPool](#aws-cdk-aws-cognito-userpool)</code> | The user pool.
+**gitUrl**? | <code>string</code> | The URL of the Git repository for the GitHub wrapper.<br/>__*Optional*__
 
 
 

--- a/API.md
+++ b/API.md
@@ -60,6 +60,7 @@ Name | Type | Description
 **clientSecret** | <code>string</code> | The client secret to be accompanied with clientId for Github APIs to authenticate the client.
 **cognitoHostedUiDomain** | <code>string</code> | The Cognito hosted UI domain.
 **userPool** | <code>[UserPool](#aws-cdk-aws-cognito-userpool)</code> | The user pool.
+**gitBranch**? | <code>string</code> | The branch of ther Git repository to clone for the GitHub wrapper.<br/>__*Optional*__
 **gitUrl**? | <code>string</code> | The URL of the Git repository for the GitHub wrapper.<br/>__*Optional*__
 
 

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,5 +1,6 @@
 FROM node:14-slim
 ARG GIT_URL
+ARG GIT_BRANCH
 
 RUN apt-get -qq update
 RUN apt-get -qq install -y --no-install-recommends \
@@ -8,7 +9,7 @@ RUN apt-get -qq install -y --no-install-recommends \
   openssh-client \
   python \
   build-essential
-RUN git clone --depth 1 --branch v1.2.0 ${GIT_URL}
+RUN git clone --depth 1 --branch ${GIT_BRANCH} ${GIT_URL}
 WORKDIR /github-cognito-openid-wrapper
 RUN npm ci
 RUN npm run build

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,4 +1,5 @@
 FROM node:14-slim
+ARG GIT_URL
 
 RUN apt-get -qq update
 RUN apt-get -qq install -y --no-install-recommends \
@@ -7,7 +8,7 @@ RUN apt-get -qq install -y --no-install-recommends \
   openssh-client \
   python \
   build-essential
-RUN git clone --depth 1 --branch v1.2.0 https://github.com/TimothyJones/github-cognito-openid-wrapper
+RUN git clone --depth 1 --branch v1.2.0 ${GIT_URL}
 WORKDIR /github-cognito-openid-wrapper
 RUN npm ci
 RUN npm run build

--- a/src/user-pool-identity-provider-github.ts
+++ b/src/user-pool-identity-provider-github.ts
@@ -20,6 +20,10 @@ export interface IUserPoolIdentityProviderGithubProps {
    * The Cognito hosted UI domain.
    */
   cognitoHostedUiDomain: string;
+  /**
+   * The URL of the Git repository for the GitHub wrapper
+   */
+  gitUrl?: string;
 }
 
 /**
@@ -49,7 +53,11 @@ export class UserPoolIdentityProviderGithub extends Construct {
     const wellKnownResource = api.root.addResource('.well-known');
 
     const commonFunctionProps = {
-      code: Code.fromDockerBuild(__dirname),
+      code: Code.fromDockerBuild(__dirname, {
+        buildArgs: {
+          GIT_URL: props.gitUrl ?? 'https://github.com/TimothyJones/github-cognito-openid-wrapper',
+        },
+      }),
       environment: {
         GITHUB_CLIENT_ID: props.clientId,
         GITHUB_CLIENT_SECRET: props.clientSecret,

--- a/src/user-pool-identity-provider-github.ts
+++ b/src/user-pool-identity-provider-github.ts
@@ -24,6 +24,10 @@ export interface IUserPoolIdentityProviderGithubProps {
    * The URL of the Git repository for the GitHub wrapper
    */
   gitUrl?: string;
+  /**
+   * The branch of ther Git repository to clone for the GitHub wrapper
+   */
+  gitBranch?: string;
 }
 
 /**
@@ -56,6 +60,7 @@ export class UserPoolIdentityProviderGithub extends Construct {
       code: Code.fromDockerBuild(__dirname, {
         buildArgs: {
           GIT_URL: props.gitUrl ?? 'https://github.com/TimothyJones/github-cognito-openid-wrapper',
+          GIT_BRANCH: props.gitBranch ?? 'v1.2.0',
         },
       }),
       environment: {


### PR DESCRIPTION
Hey, thank you for this! I wanted to modify this package to install from a custom git repository, not just https://github.com/TimothyJones/github-cognito-openid-wrapper

There are several reasons why someone might want to do this. Here are mine:
- I modified the behavior of the original wrapper (I needed to map a custom attribute)
- I am developing on an M1 Mac and one of the dev dependencies of the wrapper is incompatible Apple Sillicon, therefore I removed it so that I can run cdk locally

So I believe this is a very legitimate use case. I am happy to modify my changes to make them to your liking.